### PR TITLE
Allow the room to be re-used across calls to chat.

### DIFF
--- a/app/uk/gov/hmrc/asyncmessagebroker/repository/MessageMongoRepository.scala
+++ b/app/uk/gov/hmrc/asyncmessagebroker/repository/MessageMongoRepository.scala
@@ -48,7 +48,7 @@ object SparkMessagePersist {
 class SparkMessageMongoRepository @Inject()(mongo: DB)
   extends ReactiveRepository[SparkMessagePersist, BSONObjectID]("messages", () => mongo, SparkMessagePersist.mongoFormats, ReactiveMongoFormats.objectIdFormats)
   with AtomicUpdate[SparkMessagePersist]
-    with SparkMessageRepository
+  with SparkMessageRepository
   with BSONBuilderHelpers {
 
   override def ensureIndexes(implicit ec: ExecutionContext): Future[scala.Seq[Boolean]] = {
@@ -88,8 +88,8 @@ class SparkMessageMongoRepository @Inject()(mongo: DB)
     tokenAndDate ++ messageId ++ emailInsert
   }
 
-  def insert(clientId:String, localId:String, roomId:String, snsAction: SparkMessage): Future[DatabaseUpdate[SparkMessagePersist]] = {
-    atomicUpsert(findMessageById(localId, snsAction), modifierForInsert(snsAction, clientId, localId, roomId))
+  def insert(clientId:String, localId:String, roomId:String, message: SparkMessage): Future[DatabaseUpdate[SparkMessagePersist]] = {
+    atomicUpsert(findMessageById(localId, message), modifierForInsert(message, clientId, localId, roomId))
   }
 
   def findMessages(clientId:String, roomId:String): Future[List[SparkMessagePersist]] = {
@@ -105,7 +105,7 @@ class SparkMessageMongoRepository @Inject()(mongo: DB)
 @ImplementedBy(classOf[SparkMessageMongoRepository])
 trait SparkMessageRepository extends Repository[SparkMessagePersist, BSONObjectID] {
 
-  def insert(clientId:String, localId:String, roomId:String, snsAction: SparkMessage): Future[DatabaseUpdate[SparkMessagePersist]]
+  def insert(clientId:String, localId:String, roomId:String, message: SparkMessage): Future[DatabaseUpdate[SparkMessagePersist]]
 
   def findMessages(clientId:String, roomId:String) : Future[List[SparkMessagePersist]]
 }

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -53,7 +53,7 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/test/repository/ProfileMongoRepositorySpec.scala
+++ b/test/repository/ProfileMongoRepositorySpec.scala
@@ -38,14 +38,25 @@ class ProfileMongoRepositorySpec extends UnitSpec with ScalaFutures with WithTes
 
     "allow only 1 client be associated to 1 roomId" in {
 
-      await(profileRepository.insert("1", "2", "3"))
-      await(profileRepository.insert("1", "2", "3"))
+      await(profileRepository.insert("1", "2", "3", "4"))
+      await(profileRepository.insert("1", "2", "3", "4"))
       val allRecords = await(profileRepository.findAll())
       allRecords.size shouldBe 1
       val record: ProfilePersist = allRecords(0)
       record.clientId shouldBe "1"
       record.roomId shouldBe "2"
-      record.email shouldBe "3"
+      record.roomName shouldBe "3"
+      record.email shouldBe "4"
+    }
+
+    "find a record by room name" in {
+      await(profileRepository.insert("1", "2", "3", "4"))
+      await(profileRepository.insert("a", "b", "c", "d"))
+      val record = await(profileRepository.findProfileByRoomName("3")).get
+      record.clientId shouldBe "1"
+      record.roomId shouldBe "2"
+      record.roomName shouldBe "3"
+      record.email shouldBe "4"
     }
   }
 }


### PR DESCRIPTION
1. extend repo to store the name of the room. 
2. chat route now checks if the requested room already exists, and will re-use room Id if exists. 
3. Allow POC to demo multiple users on different devices sharing the same room. 